### PR TITLE
Cambio estado proyecto al crearse en factory

### DIFF
--- a/database/factories/ProyectoFactory.php
+++ b/database/factories/ProyectoFactory.php
@@ -18,7 +18,7 @@ class ProyectoFactory extends Factory
     {
         return [
             'titulo' => $this->faker->title,
-            'estado' => 'En Progreso',
+            'estado' => 'En Desarrollo',
             'descripcion' => $this->faker->sentence(3),
             'macro_proyecto' => MacroProyecto::inRandomOrder()->first()->id,
             'fecha_inicio' => date('Y-m-d H:i:s'),


### PR DESCRIPTION
Cambio del estado por defecto con el cual se crean los proyectos. Para tener coherencia con los requerimientos del proyecto.